### PR TITLE
front-end/router: updates router to use navigo

### DIFF
--- a/src/front-end/components/dropdown.jsx
+++ b/src/front-end/components/dropdown.jsx
@@ -1,7 +1,7 @@
 import * as dropdown from "../fillDropdown.js";
-import {adderDropdown, creationMenu, navbar} from "../index.js";
+import { adderDropdown, creationMenu, navbar } from "../index.js";
 import { currentState } from "../state/stateManager.js";
-import {router} from "../state/router.js";
+import { router } from "../state/router.js";
 
 // JSX Engine Import
 /* eslint-disable */
@@ -129,7 +129,7 @@ export class DropdownBlock extends HTMLElement {
 	 * When an object is clicked, it will toggle the page for that object
 	 */
 	navigateToObject () {
-		router.setState(`#${this.item.objectType}~${this.item.id}`, false);
+		router.navigate(`/${this.item.objectType}/${this.item.id}`);
 		navbar.open = false;
 	}
 

--- a/src/front-end/components/navbar.jsx
+++ b/src/front-end/components/navbar.jsx
@@ -1,7 +1,6 @@
 
 import { header } from "../index.js";
-import { currentState } from "../state/stateManager.js";
-import {SettingsMenu} from "./settings.jsx";
+import { SettingsMenu } from "./settings.jsx";
 import { router } from "../state/router.js";
 
 //const template = document.createElement("template");
@@ -64,7 +63,7 @@ export class NavBar extends HTMLElement {
 		this.attachShadow({ mode: "open" });
 		this.shadowRoot.appendChild(template.content.cloneNode(true));
 
-		// Main nav bar 
+		// Main nav bar
 		this.mainNav = this.shadowRoot.querySelector("#mainNav");
 		this.navShown = true;
 
@@ -154,13 +153,11 @@ export class NavBar extends HTMLElement {
 	 * Goes to home page when the home button is pressed
 	 */
 	goHome () {
-		if (document.location.hash !== null && document.location.hash !== "#index" && document.location.hash !== "") {
-			router.setState("", false);
-		}
+		router.navigate("/");
 	}
 
 	/**
-	 * toggles the collapse of the navigation bar 
+	 * toggles the collapse of the navigation bar
 	 */
 	navToggle (navShown) {
 		this.mainNav.classList.toggle("open", !navShown);
@@ -174,35 +171,6 @@ export class NavBar extends HTMLElement {
 		} else {
 			this.navShown = true;
 		}
-	}
-
-	/**
-	 * Goes to the previous page when the back button is pressed
-	 */
-	goBack () {
-		let parent = document.location.hash.includes("#dailyLog") ? "monthlyLog" : "futureLog";
-		router.setState(`#${parent}~${currentState.parent}`, false);
-	}
-
-	/**
-	 * Goes to the futureLog if you are on a dailyLog when double arrow button is clicked
-	 */
-	goFarBack () {
-		let parent = document.location.hash.includes("#dailyLog") ? "futureLog" : "index";
-		localStorage.readUser((err, user) => {
-			if (err === null) {
-				let userArr = [];
-				Array.prototype.push.apply(userArr, user.dailyLogs);
-				Array.prototype.push.apply(userArr, user.monthlyLogs);
-				Array.prototype.push.apply(userArr, user.futureLogs);
-				Array.prototype.push.apply(userArr, user.collections);
-				let parsed = userArr.filter((object) => object.id === currentState.parent);
-				let firstParent = parsed[0];
-				router.setState(`#${parent}~${firstParent.parent}`, false);
-			} else {
-				console.log(err);
-			}
-		});
 	}
 
 	/**

--- a/src/front-end/index.js
+++ b/src/front-end/index.js
@@ -6,8 +6,6 @@ import { CreationMenu } from "./components/creationMenu.jsx";
 import { InlineDropdown } from "./components/inlineDropdown.jsx";
 import { NavBar } from "./components/navbar.jsx";
 import { PageHeader } from "./components/header.jsx";
-import { router } from "./state/router.js";
-
 
 // CSS imports
 /* eslint-disable */
@@ -39,8 +37,6 @@ export let creationMenu = new CreationMenu("futureLog");
 let plusIndex = 0;
 /* eslint-disable */
 
-
-
 export let contentWrapper = document.getElementById("contentWrapper");
 document.getElementById("adderDropdown").appendChild(adderDropdown);
 document.getElementById("creationMenu").appendChild(creationMenu);
@@ -48,12 +44,4 @@ document.getElementById("topbar").appendChild(header);
 document.getElementById("sidebar").appendChild(navbar);
 document.getElementById("targetMenu").onclick = () => {
 	navbar.toggleTracker();
-};
-
-
-// Document.getElementById("")
-router.setState(document.location.hash, false);
-
-window.onpopstate = () => {
-	router.setState(document.location.hash, true);
 };

--- a/src/front-end/package-lock.json
+++ b/src/front-end/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.17.1"
+        "express": "^4.17.1",
+        "navigo": "^8.11.1"
       },
       "devDependencies": {
         "@babel/core": "^7.14.3",
@@ -9045,6 +9046,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "node_modules/navigo": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/navigo/-/navigo-8.11.1.tgz",
+      "integrity": "sha512-e3sc1UzakF+bWquC8/dbPCgo7LgPEW1ekgwb4pmEcl8tOc/I7lML8r7HBql+b0VRk7tJWTZqtkeObwJAVR1pxg=="
     },
     "node_modules/negotiator": {
       "version": "0.6.3",
@@ -20956,6 +20962,11 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
       "dev": true
+    },
+    "navigo": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/navigo/-/navigo-8.11.1.tgz",
+      "integrity": "sha512-e3sc1UzakF+bWquC8/dbPCgo7LgPEW1ekgwb4pmEcl8tOc/I7lML8r7HBql+b0VRk7tJWTZqtkeObwJAVR1pxg=="
     },
     "negotiator": {
       "version": "0.6.3",

--- a/src/front-end/package.json
+++ b/src/front-end/package.json
@@ -12,7 +12,8 @@
   "author": "CSE 110 Team 11",
   "license": "ISC",
   "dependencies": {
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "navigo": "^8.11.1"
   },
   "devDependencies": {
     "@babel/core": "^7.14.3",

--- a/src/front-end/state/setupCollection.js
+++ b/src/front-end/state/setupCollection.js
@@ -1,5 +1,4 @@
 import { contentWrapper, header } from "../index.js";
-import { setPageType, setUrl } from "./router.js";
 import { createEditor } from "../components/blockController.js";
 import { currentState } from "./stateManager.js";
 
@@ -7,18 +6,10 @@ import { currentState } from "./stateManager.js";
  * Sets up the collection page with the textBlocks and trackers of the user.
  *
  * @param {Array} btn An array of the buttons in the collection page's navbar.
- * @param {String} newState The new url to go to.
  */
- export function setupCollection (btn, newState) {
-
+export function setupCollection (btn) {
 	header.title = currentState.title;
 
-	/*
-	 * PageNumber = 5;
-	 * url = newState;
-	 */
-	setPageType(5);
-	setUrl(newState);
 	// Setting navbar buttons
 	for (let i = 0; i < btn.length; i++) {
 		btn[i].removeAttribute("disabled");

--- a/src/front-end/state/setupDailyLog.js
+++ b/src/front-end/state/setupDailyLog.js
@@ -1,29 +1,20 @@
 import * as localStorage from "../localStorage/userOperations.js";
 import { contentWrapper, header } from "../index.js";
-import { setPageType, setUrl } from "./router.js";
 import { TrackerBlock } from "../components/trackerBlock.jsx";
 import { TrackerMenu } from "../components/tracker.jsx";
 import { createEditor } from "../components/blockController.js";
 import { currentState } from "./stateManager.js";
 
-
 /**
  * Sets up the daillyLog page with the textBlocks, and trackers of the user.
  *
  * @param {Array} btn An array of the buttons in the dailyLog page's navbar.
- * @param {String} newState The new url to go to.
  */
- export function setupDailyLog (btn, newState) {
+export function setupDailyLog (btn) {
 	let monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 	let weekDays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 	header.title = `${weekDays[new Date(currentState.date).getDay()]} ${monthNames[new Date(currentState.date).getMonth()]} ${new Date(currentState.date).getUTCDate()}, ${new Date(currentState.date).getFullYear()}`;
 
-	/*
-	 * PageNumber = 2;
-	 * url = newState;
-	 */
-	setPageType(2);
-	setUrl(newState);
 	// Setting navbar buttons
 	for (let i = 0; i < btn.length; i++) {
 		btn[i].removeAttribute("disabled");

--- a/src/front-end/state/setupFutureLog.js
+++ b/src/front-end/state/setupFutureLog.js
@@ -1,6 +1,5 @@
 import * as localStorage from "../localStorage/userOperations.js";
 import { contentWrapper, header } from "../index.js";
-import { setPageType, setUrl } from "./router.js";
 import { CreatorBlock } from "../components/creator.jsx";
 import { DropdownBlock } from "../components/dropdown.jsx";
 import { TrackerBlock } from "../components/trackerBlock.jsx";
@@ -8,14 +7,12 @@ import { TrackerMenu } from "../components/tracker.jsx";
 import { createEditor } from "../components/blockController.js";
 import { currentState } from "./stateManager.js";
 
-
 /**
  * Sets up the futureLog page with the mothlyLogs, textBlocks, and trackers of the user.
  *
  * @param {Array} btn An array of the buttons in the futureLog page's navbar.
- * @param {String} newState The new url to go to.
  */
- export function setupFutureLog (btn, newState) {
+export function setupFutureLog (btn) {
 	localStorage.readUser((err, user) => {
 		if (err) {
 			console.log(err);
@@ -43,9 +40,9 @@ import { currentState } from "./stateManager.js";
 						let weekDays = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 						let dropdownDay = new DropdownBlock(`${weekDays[new Date(currentDay.date).getDay()]}, ${monthNames[new Date(currentDay.date).getMonth()]} ${new Date(currentDay.date).getUTCDate()}`, currentDay, 2);
 						dropdownMonth.contentWrapper.appendChild(dropdownDay);
-                        /* eslint-disable */
-						createEditor(dropdownDay.contentWrapper, currentMonth, currentDay.id, () => {});
-                        /* eslint-enable */
+						/* eslint-disable */
+						createEditor(dropdownDay.contentWrapper, currentMonth, currentDay.id, () => { });
+						/* eslint-enable */
 					}
 				});
 			}
@@ -57,12 +54,6 @@ import { currentState } from "./stateManager.js";
 	let futureLogEnd = new Date(currentState.endDate);
 	header.title = futureLogEnd.getFullYear() === futureLogStart.getFullYear() ? `Future Log ${futureLogStart.getFullYear()}` : `Future Log ${futureLogStart.getFullYear()} - ${futureLogEnd.getFullYear()}`;
 
-	/*
-	 * PageNumber = 4;
-	 * url = newState;
-	 */
-	setPageType(4);
-	setUrl(newState);
 	// Setting navbar buttons
 	for (let i = 0; i < btn.length; i++) {
 		btn[i].removeAttribute("disabled");

--- a/src/front-end/state/setupIndex.js
+++ b/src/front-end/state/setupIndex.js
@@ -1,17 +1,15 @@
 import * as localStorage from "../localStorage/userOperations.js";
 import { contentWrapper, header } from "../index.js"
-import { setPageType, setUrl } from "./router.js";
 import { CreatorBlock } from "../components/creator.jsx";
 import { DropdownBlock } from "../components/dropdown.jsx";
 import { currentState } from "./stateManager.js";
-
 
 /**
  * Sets up the index page with the futureLogs and collections of the user.
  *
  * @param {Array} btn An array of the buttons in the index page's navbar.
  */
- export function setupIndex (btn) {
+export function setupIndex (btn) {
 	localStorage.readUser((err, user) => {
 		if (err) {
 			console.log(err);
@@ -66,10 +64,7 @@ import { currentState } from "./stateManager.js";
 			contentWrapper.appendChild(new CreatorBlock());
 		}
 	});
-	console.log("we are here");
 	header.title = "Index";
-	setUrl("/");
-	setPageType(1);
 
 	// Setting navbar buttons
 	for (let i = 0; i < btn.length; i++) {

--- a/src/front-end/state/setupMonthlyLog.js
+++ b/src/front-end/state/setupMonthlyLog.js
@@ -1,6 +1,5 @@
 import * as localStorage from "../localStorage/userOperations.js";
 import { contentWrapper, header } from "../index.js";
-import { setPageType, setUrl } from "./router.js";
 import { CreatorBlock } from "../components/creator.jsx";
 import { DropdownBlock } from "../components/dropdown.jsx";
 import { TrackerBlock } from "../components/trackerBlock.jsx";
@@ -8,14 +7,12 @@ import { TrackerMenu } from "../components/tracker.jsx";
 import { createEditor } from "../components/blockController.js";
 import { currentState } from "./stateManager.js";
 
-
 /**
  * Sets up the monthlyLog page with the dailyLogs, textBlocks, and trackers of the user.
  *
  * @param {Array} btn An array of the buttons in the monthlyLog page's navbar.
- * @param {String} newState The new url to go to.
  */
- export function setupMonthlyLog (btn, newState) {
+export function setupMonthlyLog (btn) {
 	localStorage.readUser((err, user) => {
 		if (err) {
 			console.log(err);
@@ -46,12 +43,6 @@ import { currentState } from "./stateManager.js";
 	let monthNames = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
 	header.title = `${monthNames[new Date(currentState.date).getMonth()]} ${new Date(currentState.date).getFullYear()}`;
 
-	/*
-	 * PageNumber = 3;
-	 * url = newState;
-	 */
-	setPageType(3);
-	setUrl(newState);
 	// Setting navbar buttons
 	for (let i = 0; i < btn.length; i++) {
 		btn[i].removeAttribute("disabled");

--- a/src/front-end/state/stateManager.js
+++ b/src/front-end/state/stateManager.js
@@ -15,23 +15,11 @@ export let currentState = {};
  *
  * @param {String} urlFromRouter The current url.
  */
-
-export function getCurrentObject (urlFromRouter) {
-	let urlparse = "";
-	let id = null;
-	if (urlFromRouter !== null) {
-		urlparse = urlFromRouter.split("~");
-	}
-	console.log(urlparse !== undefined);
-	if (urlparse !== undefined) {
-		id = urlparse[1];
-	}
+export function getCurrentObject (id) {
 	localStorage.readUser((err, user) => {
 		if (err) {
 			window.location.href = "/login";
-		} else if (id === undefined || id === null) {
-			currentState = user.index;
-		} else {
+		} else if (id) {
 			let userArr = [];
 			Array.prototype.push.apply(userArr, user.dailyLogs);
 			Array.prototype.push.apply(userArr, user.monthlyLogs);
@@ -39,8 +27,8 @@ export function getCurrentObject (urlFromRouter) {
 			Array.prototype.push.apply(userArr, user.collections);
 			let parsed = userArr.filter((object) => object.id === id);
 			currentState = parsed[0];
+		} else {
+			currentState = user.index;
 		}
 	});
-
 }
-

--- a/src/front-end/transitions.js
+++ b/src/front-end/transitions.js
@@ -14,22 +14,22 @@
  * @param {Object} element The element the transition occurs on.
  * @param {singleParameterCallback} callback Function for when transition end is true.
  */
- export function fade (element, callback) {
-    // Initial opacity
-    let op = 1;
-        let timer = setInterval(() => {
-			let end = false;
-			if (op <= 0.1) {
-				clearInterval(timer);
-				element.style.display = "none";
-				end = true;
-			}
-			element.style.opacity = op;
-			op -= op * 0.1;
-			if (end) {
-				callback();
-			}
-		}, 10);
+export function fade (element, callback) {
+	// Initial opacity
+	let op = 1;
+	let timer = setInterval(() => {
+		let end = false;
+		if (op <= 0.1) {
+			clearInterval(timer);
+			element.style.display = "none";
+			end = true;
+		}
+		element.style.opacity = op;
+		op -= op * 0.1;
+		if (end && callback) {
+			callback();
+		}
+	}, 10);
 }
 
 /**
@@ -47,16 +47,16 @@ export function unfade (element, callback) {
 	let end = false;
 	// Initial opacity
 	let op = 0.1;
-    element.style.opacity = op;
+	element.style.opacity = op;
 	element.style.display = "block";
-	let timer = setInterval(() =>{
+	let timer = setInterval(() => {
 		if (op >= 1) {
 			clearInterval(timer);
 			end = true;
 		}
 		element.style.opacity = op;
 		op += op * 0.1;
-		if (end) {
+		if (end && callback) {
 			callback();
 		}
 	}, 10);

--- a/src/unitTests/components/dropdown.js
+++ b/src/unitTests/components/dropdown.js
@@ -1,4 +1,4 @@
-import {router} from "../router.js";
+import { router } from "../router.js";
 const tabspace = 3;
 
 export class DropdownBlock extends HTMLElement {
@@ -16,10 +16,10 @@ export class DropdownBlock extends HTMLElement {
 
 			#wrapper{
 				padding-bottom: 0;
-				user-select: none; 
+				user-select: none;
 				-webkit-user-select: none;
-				-moz-user-select: none; 
-				-khtml-user-select: none; 
+				-moz-user-select: none;
+				-khtml-user-select: none;
 				-ms-user-select: none;
 			}
 
@@ -124,7 +124,7 @@ export class DropdownBlock extends HTMLElement {
     }
 
 	navigateToObject() {
-		router.setState(`#${this.item.objectType}~${this.item.id}`, false);
+		router.navigate(`/${this.item.objectType}/${this.item.id}`);
 	}
 
     display() {

--- a/src/unitTests/components/navbar.js
+++ b/src/unitTests/components/navbar.js
@@ -3,7 +3,7 @@ const template = document.createElement('template');
 template.innerHTML = `
 	<style>
 		.navigation {
-			display: none; 
+			display: none;
 		}
 
 		.nav-bar {
@@ -15,7 +15,7 @@ template.innerHTML = `
 			left: 0;
 			display: block;
 			background: rgba(236, 223, 207, 0.4);
-			
+
 
 		}
 
@@ -111,7 +111,7 @@ template.innerHTML = `
 			.nav-bar {
 				display:none;
 			}
-			
+
 			.navigation {
 				display: block;
 				background-color: rgba(236, 223, 207, 0.0);
@@ -123,7 +123,7 @@ template.innerHTML = `
 				left: 0;
 				position:fixed;
 			}
-			  
+
 			#menu {
 				position: fixed;
 				width: 30%;
@@ -135,19 +135,19 @@ template.innerHTML = `
 				padding: 0;
 				background-color: white;
 			}
-	
+
 			.menuClosed{
 				-webkit-font-smoothing: antialiased;
 				transform: translate(-100%, 0);
 				transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 			}
-	
+
 			.menuOpen{
 				-webkit-font-smoothing: antialiased;
 				transform-origin: 0 0;
 				transition: transform 0.5s cubic-bezier(0.77,0.2,0.05,1.0);
 			}
-	
+
 			#homeMenu {
 				background-image: url(../public/resources/home_icon.png);
 				background-size: cover;
@@ -162,7 +162,7 @@ template.innerHTML = `
 				right: 0;
 				margin: auto;
 			}
-	
+
 			#singleMenu {
 				background-image: url(../public/resources/left.png);
 				background-size: cover;
@@ -177,7 +177,7 @@ template.innerHTML = `
 				right: 0;
 				margin: auto;
 			}
-	
+
 			#doubleMenu {
 				background-image: url(../public/resources/double_icon.png);
 				background-size: cover;
@@ -192,7 +192,7 @@ template.innerHTML = `
 				right: 0;
 				margin: auto;
 			}
-	
+
 			#userMenu {
 				background-image: url(../public/resources/user.png);
 				background-size: cover;
@@ -208,33 +208,33 @@ template.innerHTML = `
 				padding: 0;
 				margin: 0 auto;
 			}
-	
-			  
+
+
 			  #menuToggle input:checked ~ ul
 			  {
 				transform: none;
 			  }
-	 
+
 		}
-	
+
 		@media only screen and (max-height: 1200px){
 			#homeMenu {
 				width: 40px;
 				height: 40px;
 			}
-	
+
 			#singleMenu {
 				width: 40px;
 				height: 40px;
 				top: 150px;
 			}
-	
+
 			#doubleMenu {
 				width: 40px;
 				height: 40px;
 				top: 230px;
 			}
-	
+
 			#userMenu {
 				position: absolute;
 				width: 45px;
@@ -242,25 +242,25 @@ template.innerHTML = `
 				top: calc(100% - 85px);
 			}
 		}
-	
+
 		@media only screen and (max-height: 800px){
 			#homeMenu {
 				width: 35px;
 				height: 35px;
 			}
-	
+
 			#singleMenu {
 				width: 35px;
 				height: 35px;
 				top: 130px;
 			}
-	
+
 			#doubleMenu {
 				width: 35px;
 				height: 35px;
 				top: 190px;
 			}
-	
+
 			#userMenu {
 				position: absolute;
 				width: 40px;
@@ -269,7 +269,7 @@ template.innerHTML = `
 			}
 		}
 
-	</style> 
+	</style>
 
 	<nav class="nav-bar">
 		<ul>
@@ -323,7 +323,7 @@ export class NavBar extends HTMLElement {
 			this.goFarBack();
 		});
 		this.user.addEventListener('click', () => {
-			alert("hello"); 
+			alert("hello");
 		});
 
 		this.homeMenu.addEventListener('click', () => {
@@ -342,23 +342,20 @@ export class NavBar extends HTMLElement {
 			header.input.checked = false;
 		});
 		this.userMenu.addEventListener('click', () => {
-			alert("hello"); 
+			alert("hello");
 			this.toggleMenu();
 			header.input.checked = false;
 		});
 	}
 
-	goHome(){
-		if (document.location.hash != null && document.location.hash != "#index" && document.location.hash !=''){
-			router.setState("", false);
-		}
+	goHome() {
+		router.navigate("/");
 	}
 
-	goBack(){
-		let parent = (document.location.hash.includes("#dailyLog")) ? "monthlyLog" : "futureLog";
-		router.setState(`#${parent}~${currentObject.parent}`, false);
+	goBack() {
+		let parent = (document.location.pathname.startsWith("/dailyLog")) ? "monthlyLog" : "futureLog";
+		router.navigate(`/${parent}/${currentObject.parent}`);
 	}
-
 
 	toggleTracker() {
 		const trackerMenu = document.querySelector("tracker-menu");


### PR DESCRIPTION
Updates the frontend routing to use more conventional routes. While
hash-based routing is still used, routes now look more like standard
URIs.

The new routes are:
/dailyLog/:id
/monthlyLog/:id
/futureLog/:id
/collection/:id
Which look like boojo.app/#/dailyLog/BCykNlF2a4MCiIvKfQJCaC66JvzEZg

The router.js file is refactored to only export the Navigo router
object. This is needed in some cases to change the route using
javascript. The preferred way to change the route will always be using
HTML. The way to do this is by using the <a> element with the
data-navigo attribute.

Example:
`<a href="/dailyLog/BCykNlF2a4MCiIvKfQJCaC66JvzEZg" data-navigo>`

Link to the Navigo documentation:
https://github.com/krasimir/navigo/blob/master/DOCUMENTATION.md