### PR TITLE
back-end/index: fixes cookies not working in production due to proxies

### DIFF
--- a/src/back-end/constants.js
+++ b/src/back-end/constants.js
@@ -4,6 +4,7 @@
 module.exports = {
     accessControlOrigin: "*",
     sessionSecret: "wA531Y0qA3dhU8lxHElEhmomOM7P42WA",
+    reverseProxy: false,
     sessionCookieObject: {
         path: "/",
         httpOnly: false,

--- a/src/back-end/constants_prod.js
+++ b/src/back-end/constants_prod.js
@@ -6,6 +6,7 @@ require("dotenv").config();
 module.exports = {
     accessControlOrigin: "https://boojo.bitfrost.app",
     sessionSecret: process.env.SESSION_SECRET,
+    reverseProxy: true,
     sessionCookieObject: {
         path: "/",
         httpOnly: true,

--- a/src/back-end/index.js
+++ b/src/back-end/index.js
@@ -28,6 +28,7 @@ app.use((req, res, next) => {
 app.use(session({
     secret: constants.sessionSecret,
     saveUninitialized: false,
+    proxy: constants.reverseProxy,
     cookie: constants.sessionCookieObject,
     resave: false,
     name: "sessionAuth"

--- a/src/front-end/localStorage/updateFiles/updateUser.js
+++ b/src/front-end/localStorage/updateFiles/updateUser.js
@@ -17,7 +17,7 @@ import { api, origin } from "../../constants.js";
 				console.log("this is the user now", doc);
 				console.log("about to fetch");
 				fetch(`${api}/user`, {
-                    credentials: "same-origin",
+                    credentials: "include",
 					headers: {
 						"content-type": "application/json; charset=UTF-8",
 						"Origin": origin

--- a/src/front-end/login/login.js
+++ b/src/front-end/login/login.js
@@ -68,10 +68,14 @@ createAccount.onclick = (e) => {
 			} else if (user.email === undefined) {
 				alert("Wrong username or password");
 			} else {
-				user.pwd = password.value;
-				createUserPouch(db, user, (userData) => {
-					console.log(userData);
-					window.location.href = "/";
+				createUserPouch(db, user, () => {
+					loginUser(email.value, password.value, (err) => {
+						if (err.error) {
+							alert(err.error);
+						} else {
+							window.location.href = "/";
+						}
+					});
 				});
 			}
 		});


### PR DESCRIPTION
The back-end is behind a reverse proxy and communicates to that proxy
via HTTP. Secure cookies will not work over HTTP, so despite the
reverse proxy only sending traffic over HTTPS, express refused to send
the cookie. This fixes the issue by having the reverse proxy set the
X-Forward-Proto header (not something handled in this commit or repo),
and setting the express-session value 'proxy' to true when in
production.

---
**front-end/updateUser: modifies updateUserOnline to use cred include**

This was using same-origin, but that broke stuff with CORS, so we needed
to change all the fetches to use include. This fetch was missed.

---
**front-end/login: auths users on account creation**

Previously users were not authed on account creation. This fixes the
issue by authenticating users once accounts are created. This makes sure
the session cookie gets set when the user enters the application through
the "Create Account" button and that it is known as valid on the
backend.