### PR TITLE
back-end/test/updateFiles: add tests for updateFiles

### DIFF
--- a/src/back-end/test/readFiles.test.js
+++ b/src/back-end/test/readFiles.test.js
@@ -96,7 +96,7 @@ describe("authenticate() Tests", () => {
      */
     const insertUser = async (user) => {
         await new schema.User(user).save();
-        let insertedUser = await updateUser(user.email, ENCRYPTION_KEY, JSON.parse(JSON.stringify(user)));
+        let insertedUser = await updateUser(user.email, ENCRYPTION_KEY, user);
         return insertedUser;
     };
 

--- a/src/back-end/test/readFiles.test.js
+++ b/src/back-end/test/readFiles.test.js
@@ -11,7 +11,7 @@ const { readUser } = require("../readFiles/readUser.js");
 const { updateUser } = require("../updateFiles/updateUser.js");
 const mongoose = require("mongoose");
 
-describe("authenticate() Tests", () => {
+describe("readUser() Tests", () => {
     const ENCRYPTION_KEY = "KEYKEYKEYKEYKEYKEYKEYKEY";
 
     /**

--- a/src/back-end/test/readFiles.test.js
+++ b/src/back-end/test/readFiles.test.js
@@ -394,13 +394,16 @@ describe("readUser() Tests", () => {
         expect(user).toEqual(insertedUser);
     });
 
-    test("User does not exist", async () => {
-        try {
-            await readUser("user@example.com", ENCRYPTION_KEY);
+    test("User does not exist", (done) => {
+        readUser("user@example.com", ENCRYPTION_KEY).
+        then(() => {
             expect(true).toBe(false);
-        } catch (err) {
+            done();
+        }).
+        catch((err) => {
             expect(err.message).toBe("User does not exist!");
-        }
+            done();
+        });
     });
 
     test("User password isn't returned", async () => {

--- a/src/back-end/test/updateFiles.test.js
+++ b/src/back-end/test/updateFiles.test.js
@@ -1,0 +1,548 @@
+/**
+ * Tests exported security functions.
+ */
+
+/* Mock envvars */
+process.env.HASHKEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+
+/* Imports */
+const schema = require("../schema.js");
+const { readUser } = require("../readFiles/readUser.js");
+const { updateUser } = require("../updateFiles/updateUser.js");
+const security = require("../security/securityFunctions.js");
+const mongoose = require("mongoose");
+
+/* eslint-disable max-lines-per-function */
+describe("updateUser() Tests", () => {
+    const ENCRYPTION_KEY = "KEYKEYKEYKEYKEYKEYKEYKEY";
+
+    /**
+     * Create an empty user object with the username and password.
+     *
+     * @param {String} email The email of the user to create.
+     * @param {String} password The password of the user.
+     */
+    const createEmptyUser = (email, password) => ({
+            email: email,
+            pwd: security.passHash(password ?? "password"),
+            theme: "lightmode",
+            index: {
+                objectType: "index",
+                contents: []
+            },
+            dailyLogs: [],
+            monthlyLogs: [],
+            futureLogs: [],
+            trackers: [],
+            collections: [],
+            imageBlocks: [],
+            audioBlocks: [],
+            textBlocks: [],
+            events: [],
+            tasks: [],
+            signifiers: []
+        });
+
+    /**
+     * Removes Mongo userIds from userdata.
+     *
+     * @param {Object} user The object to remove the IDs from.
+     */
+    const removeIds = (user) => {
+        delete user.__v;
+        delete user._id;
+        for (let obj of user.dailyLogs) {
+            delete obj._id;
+        }
+        for (let obj of user.monthlyLogs) {
+            delete obj._id;
+            for (let day of obj.days) {
+                delete day._id;
+            }
+        }
+        for (let obj of user.futureLogs) {
+            delete obj._id;
+            for (let month of obj.months) {
+                delete month._id;
+            }
+        }
+        for (let obj of user.trackers) {
+            delete obj._id;
+        }
+        for (let obj of user.collections) {
+            delete obj._id;
+        }
+        for (let obj of user.imageBlocks) {
+            delete obj._id;
+        }
+        for (let obj of user.audioBlocks) {
+            delete obj._id;
+        }
+        for (let obj of user.textBlocks) {
+            delete obj._id;
+        }
+        for (let obj of user.events) {
+            delete obj._id;
+        }
+        for (let obj of user.tasks) {
+            delete obj._id;
+        }
+        for (let obj of user.signifiers) {
+            delete obj._id;
+        }
+        return user;
+    };
+
+    /**
+     * Inserts a user into the database.
+     *
+     * @param {Object} user The user to insert.
+     */
+    const insertUser = async (user) => {
+        await new schema.User(user).save();
+    };
+
+    /**
+     * Gets a user with all it's data still encrypted.
+     *
+     * @param {String} email The email of the user to find.
+     * @returns A user if found, null otherwise.
+     */
+    const getUser = async (email) => {
+        const user = await schema.User.findOne({ email: email }).exec();
+        return user;
+    };
+
+    /* Connect to the in-memory Mongo server */
+    beforeAll(async () => {
+        mongoose.set("useCreateIndex", true);
+        await mongoose.connect(`${globalThis.__MONGO_URI__}${globalThis.__MONGO_DB_NAME__}`, {
+            useUnifiedTopology: true,
+            useNewUrlParser: true
+        });
+    });
+
+    /* Drop the database */
+    afterEach(async () => {
+        await schema.User.deleteMany({});
+    });
+
+    /* Clean up the connection */
+    afterAll(async () => {
+        await mongoose.connection.close();
+    });
+
+    test("User can't update email", async (done) => {
+        const USER_EMAIL = "user@example.com";
+        const BAD_EMAIL = "other@example.com";
+
+        const insertedUser = createEmptyUser(USER_EMAIL);
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* User returned by updateUser should not have a new email */
+        let user = await updateUser(USER_EMAIL, ENCRYPTION_KEY, createEmptyUser(BAD_EMAIL));
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* This should also be reflected by readUser */
+        user = await readUser(USER_EMAIL, ENCRYPTION_KEY);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* The user with the other email should not exist */
+        readUser(BAD_EMAIL, ENCRYPTION_KEY).
+        then(() => {
+            expect(true).toBe(false);
+            done();
+        }).
+        catch((err) => {
+            expect(err.message).toBe("User does not exist!");
+            done();
+        });
+    });
+
+    test("User can't update password", async () => {
+        const PASSWORD = "password";
+        const insertedUser = createEmptyUser("user@example.com", PASSWORD);
+        await insertUser(insertedUser);
+
+        await updateUser(insertedUser.email, ENCRYPTION_KEY, createEmptyUser(insertedUser.email, "newPassword"));
+        const user = await getUser(insertedUser.email);
+        expect(user.pwd).toBe(insertedUser.pwd);
+    });
+
+    test("Password is not returned", async () => {
+        const insertedUser = createEmptyUser("user@example.com", "password");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        const user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        expect(user.pwd).toBeUndefined();
+    });
+
+    test("Update user with collection", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.collections.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            title: "Collection",
+            parent: "CAFEBEEF",
+            content: ["First", "Second", "Third"]
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.collections[0].title, ENCRYPTION_KEY)).toBe(insertedUser.collections[0].title);
+    });
+
+    test("Update user with text block", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.textBlocks.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            tabLevel: 0,
+            parent: "BEEFBEEF",
+            subParent: "CAFECAFE",
+            kind: "Event",
+            objectReference: "DEADEAD",
+            text: "This is some text",
+            signifier: "orange"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.textBlocks[0].text, ENCRYPTION_KEY)).toBe(insertedUser.textBlocks[0].text);
+    });
+
+    test("Update user with task", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.tasks.push({
+            id: "CAFEBEEF",
+            objectType: "task",
+            parent: "DEADBEEF",
+            text: "A task",
+            complete: 0,
+            signifier: "AAAAAAAAAAAAAAAAAAAAAAAAa"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.tasks[0].text, ENCRYPTION_KEY)).toBe(insertedUser.tasks[0].text);
+    });
+
+    test("Update user with event", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.events.push({
+            id: "CAFEBEEF",
+            objectType: "signifier",
+            title: "A title",
+            parent: "DEADBEEF",
+            date: JSON.parse(JSON.stringify(new Date())),
+            signifier: "Orange"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.events[0].title, ENCRYPTION_KEY)).toBe(insertedUser.events[0].title);
+    });
+
+    test("Update user with signifier", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.signifiers.push({
+            id: "CAFEBEEF",
+            objectType: "signifier",
+            meaning: "general",
+            symbol: "&#x1F7E0;"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.signifiers[0].meaning, ENCRYPTION_KEY)).toBe(insertedUser.signifiers[0].meaning);
+    });
+
+    test("Update user with trackers", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.trackers.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            title: "Tacker",
+            content: ["Lorem", "Ipsum", "Novo"],
+            parent: "CAFEBEEF"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Check for valid encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.trackers[0].title, ENCRYPTION_KEY)).toBe(insertedUser.trackers[0].title);
+    });
+
+    test("Update user with daily log", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.dailyLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            date: JSON.parse(JSON.stringify(new Date(0))),
+            parent: "CAFEBEEF",
+            content: ["First String", "Second String", "Third String"],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+    });
+
+    test("Update user with monthly log", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.monthlyLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            parent: "CAFEBEEF",
+            date: JSON.parse(JSON.stringify(new Date(0))),
+            days: [
+                {
+                    id: "CAFECAFE",
+                    content: ["Some content", "other content", "more content"],
+                    dailyLog: "BEEFBEEF"
+                }
+            ],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+    });
+
+    test("Update user with future log", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.futureLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            startDate: JSON.parse(JSON.stringify(new Date(0))),
+            endDate: JSON.parse(JSON.stringify(new Date(100000000))),
+            months: [
+                {
+                    id: "CAFECAFE",
+                    content: ["Some content", "other content", "more content"],
+                    monthlyLog: "BEEFBEEF"
+                }
+            ],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+    });
+
+    test("Update user theme", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.theme = "darkmode";
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+    });
+
+    test("Update user index", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.index = { objectType: "index", contents: ["One", "Two", "Three"] };
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+    });
+
+    test("Update everything", async () => {
+        const insertedUser = createEmptyUser("user@example.com");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        /* Test for valid insertion */
+        insertedUser.index = { objectType: "index", contents: ["One", "Two", "Three"] };
+        insertedUser.theme = "darkmode";
+        insertedUser.dailyLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            date: JSON.parse(JSON.stringify(new Date(0))),
+            parent: "CAFEBEEF",
+            content: ["First String", "Second String", "Third String"],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        insertedUser.monthlyLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            parent: "CAFEBEEF",
+            date: JSON.parse(JSON.stringify(new Date(0))),
+            days: [
+                {
+                    id: "CAFECAFE",
+                    content: ["Some content", "other content", "more content"],
+                    dailyLog: "BEEFBEEF"
+                }
+            ],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        insertedUser.futureLogs.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            startDate: JSON.parse(JSON.stringify(new Date(0))),
+            endDate: JSON.parse(JSON.stringify(new Date(100000000))),
+            months: [
+                {
+                    id: "CAFECAFE",
+                    content: ["Some content", "other content", "more content"],
+                    monthlyLog: "BEEFBEEF"
+                }
+            ],
+            trackers: ["First Tracker", "Second Tracker", "Third Tracker"]
+        });
+        insertedUser.trackers.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            title: "Tacker",
+            content: ["Lorem", "Ipsum", "Novo"],
+            parent: "CAFEBEEF"
+        });
+        insertedUser.collections.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            title: "Collection",
+            parent: "CAFEBEEF",
+            content: ["First", "Second", "Third"]
+        });
+        insertedUser.textBlocks.push({
+            id: "DEADBEEF",
+            objectType: "signifier",
+            tabLevel: 0,
+            parent: "BEEFBEEF",
+            subParent: "CAFECAFE",
+            kind: "Event",
+            objectReference: "DEADEAD",
+            text: "This is some text",
+            signifier: "orange"
+        });
+        insertedUser.events.push({
+            id: "CAFEBEEF",
+            objectType: "signifier",
+            title: "A title",
+            parent: "DEADBEEF",
+            date: JSON.parse(JSON.stringify(new Date())),
+            signifier: "Orange"
+        });
+        insertedUser.tasks.push({
+            id: "CAFEBEEF",
+            objectType: "task",
+            parent: "DEADBEEF",
+            text: "A task",
+            complete: 0,
+            signifier: "AAAAAAAAAAAAAAAAAAAAAAAAa"
+        });
+        insertedUser.signifiers.push({
+            id: "CAFEBEEF",
+            objectType: "signifier",
+            meaning: "general",
+            symbol: "&#x1F7E0;"
+        });
+        let user = await updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser);
+        user = removeIds(JSON.parse(JSON.stringify(user)));
+        expect(user).toEqual(insertedUser);
+
+        /* Verify encryption */
+        user = await getUser(insertedUser.email);
+        expect(security.decrypt(user.collections[0].title, ENCRYPTION_KEY)).toBe(insertedUser.collections[0].title);
+        expect(security.decrypt(user.textBlocks[0].text, ENCRYPTION_KEY)).toBe(insertedUser.textBlocks[0].text);
+        expect(security.decrypt(user.tasks[0].text, ENCRYPTION_KEY)).toBe(insertedUser.tasks[0].text);
+        expect(security.decrypt(user.events[0].title, ENCRYPTION_KEY)).toBe(insertedUser.events[0].title);
+        expect(security.decrypt(user.signifiers[0].meaning, ENCRYPTION_KEY)).toBe(insertedUser.signifiers[0].meaning);
+        expect(security.decrypt(user.trackers[0].title, ENCRYPTION_KEY)).toBe(insertedUser.trackers[0].title);
+    });
+
+    test("Update user that doesn't exist", (done) => {
+        const badUser = createEmptyUser("user@example.com", "password");
+        delete badUser.pwd;
+
+        updateUser(badUser.email, ENCRYPTION_KEY, badUser).
+        then(() => {
+            expect(true).toBe(false);
+            done();
+        }).
+        catch((err) => {
+            expect(err.message).toBe("User does not exist!");
+            done();
+        });
+    });
+
+    test("Update user with bad schema", async (done) => {
+        const insertedUser = createEmptyUser("user@example.com", "password");
+        await insertUser(insertedUser);
+        delete insertedUser.pwd;
+
+        delete insertedUser.dailyLogs;
+        updateUser(insertedUser.email, ENCRYPTION_KEY, insertedUser).
+        then(() => {
+            expect(true).toBe(false);
+            done();
+        }).
+        catch(() => done());
+    });
+});
+/* eslint-enable max-lines-per-function */

--- a/src/back-end/updateFiles/updateUser.js
+++ b/src/back-end/updateFiles/updateUser.js
@@ -3,6 +3,7 @@
  * @namespace mongoUpdate
  */
 require("dotenv").config();
+const readUser = require(`${__dirname}/../readFiles/readUser`);
 const security = require(`${__dirname}/../security/securityFunctions.js`);
 const schema = require(`${__dirname}/../schema.js`);
 
@@ -65,7 +66,7 @@ const updateUser = async (email, key, userObject) => {
 		newTrackers.push(tracker);
 	}
 
-	const user = await schema.User.findOne({ email: email }).exec();
+	let user = await schema.User.findOne({ email: email }).exec();
 	if (user === null) {
 		throw new Error("User does not exist");
 	}
@@ -83,9 +84,9 @@ const updateUser = async (email, key, userObject) => {
 	user.events = newEvents;
 	user.signifiers = newSignifiers;
 
-	const newUser = await user.save();
-	delete newUser.pwd;
-	return newUser;
+	await user.save();
+	user = await readUser.readUser(user.email, key);
+	return user;
 };
 
 module.exports = {

--- a/src/back-end/updateFiles/updateUser.js
+++ b/src/back-end/updateFiles/updateUser.js
@@ -17,51 +17,52 @@ const schema = require(`${__dirname}/../schema.js`);
  * @reject An error.
  */
 const updateUser = async (email, key, userObject) => {
+	let userCopy = JSON.parse(JSON.stringify(userObject));
 	let newCollections = [];
-	for (let i = 0; i < userObject.collections.length; i++) {
-		let collection = userObject.collections[i];
+	for (let i = 0; i < userCopy.collections.length; i++) {
+		let collection = userCopy.collections[i];
 		collection.title = security.encrypt(collection.title, key);
 		newCollections.push(collection);
 	}
 	let newTextBlocks = [];
-	for (let i = 0; i < userObject.textBlocks.length; i++) {
-		let block = userObject.textBlocks[i];
+	for (let i = 0; i < userCopy.textBlocks.length; i++) {
+		let block = userCopy.textBlocks[i];
 		block.text = security.encrypt(block.text, key);
 		newTextBlocks.push(block);
 	}
 	let newTasks = [];
-	for (let i = 0; i < userObject.tasks.length; i++) {
-		let block = userObject.tasks[i];
+	for (let i = 0; i < userCopy.tasks.length; i++) {
+		let block = userCopy.tasks[i];
 		block.text = security.encrypt(block.text, key);
 		newTasks.push(block);
 	}
 	let newEvents = [];
-	for (let i = 0; i < userObject.events.length; i++) {
-		let block = userObject.events[i];
+	for (let i = 0; i < userCopy.events.length; i++) {
+		let block = userCopy.events[i];
 		block.title = security.encrypt(block.title, key);
 		newEvents.push(block);
 	}
 	let newSignifiers = [];
-	for (let i = 0; i < userObject.signifiers.length; i++) {
-		let signifier = userObject.signifiers[i];
+	for (let i = 0; i < userCopy.signifiers.length; i++) {
+		let signifier = userCopy.signifiers[i];
 		signifier.meaning = security.encrypt(signifier.meaning, key);
 		newSignifiers.push(signifier);
 	}
 	let newImageBlocks = [];
-	for (let i = 0; i < userObject.imageBlocks.length; i++) {
-		let imageBlock = userObject.imageBlocks[i];
+	for (let i = 0; i < userCopy.imageBlocks.length; i++) {
+		let imageBlock = userCopy.imageBlocks[i];
 		imageBlock.data = security.encrypt(imageBlock.data, key);
 		newImageBlocks.push(imageBlock);
 	}
 	let newAudioBlocks = [];
-	for (let i = 0; i < userObject.audioBlocks.length; i++) {
-		let audioBlock = userObject.audioBlocks[i];
+	for (let i = 0; i < userCopy.audioBlocks.length; i++) {
+		let audioBlock = userCopy.audioBlocks[i];
 		audioBlock.data = security.encrypt(audioBlock.data, key);
 		newAudioBlocks.push(audioBlock);
 	}
 	let newTrackers = [];
-	for (let i = 0; i < userObject.trackers.length; i++) {
-		let tracker = userObject.trackers[i];
+	for (let i = 0; i < userCopy.trackers.length; i++) {
+		let tracker = userCopy.trackers[i];
 		tracker.title = security.encrypt(tracker.title, key);
 		newTrackers.push(tracker);
 	}
@@ -70,11 +71,11 @@ const updateUser = async (email, key, userObject) => {
 	if (user === null) {
 		throw new Error("User does not exist");
 	}
-	user.index = userObject.index;
-	user.theme = userObject.theme;
-	user.dailyLogs = userObject.dailyLogs;
-	user.monthlyLogs = userObject.monthlyLogs;
-	user.futureLogs = userObject.futureLogs;
+	user.index = userCopy.index;
+	user.theme = userCopy.theme;
+	user.dailyLogs = userCopy.dailyLogs;
+	user.monthlyLogs = userCopy.monthlyLogs;
+	user.futureLogs = userCopy.futureLogs;
 	user.collections = newCollections;
 	user.trackers = newTrackers;
 	user.imageBlocks = newImageBlocks;

--- a/src/back-end/updateFiles/updateUser.js
+++ b/src/back-end/updateFiles/updateUser.js
@@ -69,7 +69,7 @@ const updateUser = async (email, key, userObject) => {
 
 	let user = await schema.User.findOne({ email: email }).exec();
 	if (user === null) {
-		throw new Error("User does not exist");
+		throw new Error("User does not exist!");
 	}
 	user.index = userCopy.index;
 	user.theme = userCopy.theme;


### PR DESCRIPTION
There are several small commits here as well that fix little issues found during development.

---

[back-end/updateFiles/updateUser: change to return decrypted user](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/71df1d35d03bda1c435803e66f70ad69dcd8f4db)

There's not much of a reason to return the encrypted user, so this
commit changes the behavior to return the decrypted user instead. It
does this simply by calling readUser and returning the result. This is
preferable to just using the userObject because there may be new,
internal Mongo/Mongoose values present after insertion.

---

[back-end/updateFiles/updateUser: add deep copy of user object](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/dc1c97414e08a50c62f41a963dbfa9f0a97ee503)

Makes updateUser do a deep copy of the userObject arguement. This is to
prevent it from being modified when it shouldn't be. It also isn't
documented that it will be modifying userObject, so this bring
functionality in line with what a user would expect.

---

[back-end/test/readFiles: fix description of tests](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/db8c30d03d4c492de88bb3de862ec540465bb6ff)

I copied the boiler plate from some tests in security.test.js and forgot
to update the description.

---

[back-end/updateFiles/updateUser: fix inconsistent wording in error](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/b5f8fcb02e9fb4692e2aa725ea726dda9ecb4f40)

This is slightly different than the same error thrown by readUser().

---

[back-end/test/readFiles: removes try-catch from expect statements](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/b402a7f5cce8a354785df8ff4a3f1665700ac6e3)

expect works by throwing exceptions, so when tests catch them, that is
bad. This fixes the issue by using then() and catch() on promises which
doesn't replicate this issue.