### PR TITLE
back-end: Fixes critical encryption bug and finishes express e2e testing

### DIFF
--- a/src/back-end/createFiles/createUser.js
+++ b/src/back-end/createFiles/createUser.js
@@ -79,6 +79,7 @@ const createUser = async (email, pwd, key) => {
 		]
 	});
 	user = await user.save();
+	user = user.toObject();
 	user.signifiers[0].meaning = "general";
 	delete user.pwd;
 	return user;

--- a/src/back-end/deleteFiles/deleteUser.js
+++ b/src/back-end/deleteFiles/deleteUser.js
@@ -13,7 +13,7 @@ const schema = require(`${__dirname}/../schema.js`);
  * @reject An error.
  */
 const deleteUser = async (email) => {
-	const user = await schema.User.findOneAndDelete({ email: email }).exec();
+	let user = await schema.User.findOneAndDelete({ email: email }).lean();
 	if (user === null) {
 		throw new Error("User does not exist!");
 	}

--- a/src/back-end/test/app.test.js
+++ b/src/back-end/test/app.test.js
@@ -7,8 +7,8 @@ process.env.HASHKEY = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
 
 /* Imports */
 const app = require("../app.js");
-const constants = require("../constants.js");
 const createUser = require("../createFiles/createUser.js");
+const readUser = require("../readFiles/readUser.js");
 const schema = require("../schema.js");
 const security = require("../security/securityFunctions.js");
 const mongoose = require("mongoose");
@@ -17,10 +17,61 @@ const request = require("supertest");
 /**
  * Generates the user's encryption key from their password.
  *
+ * @param {String} email The email of the user.
  * @param {String} password The password to generate the key from.
  * @returns The symmetric encryption key for user data.
  */
-const genKeyFromPass = (password) => security.passHash(security.encrypt(password, constants.sessionSecret));
+const genKeyFromPass = (email, password) => security.passHash(email + password);
+
+/**
+ * Removes Mongo userIds from userdata.
+ *
+ * @param {Object} user The object to remove the IDs from.
+ */
+const removeIds = (user) => {
+    delete user.__v;
+    delete user._id;
+    for (let obj of user.dailyLogs) {
+        delete obj._id;
+    }
+    for (let obj of user.monthlyLogs) {
+        delete obj._id;
+        for (let day of obj.days) {
+            delete day._id;
+        }
+    }
+    for (let obj of user.futureLogs) {
+        delete obj._id;
+        for (let month of obj.months) {
+            delete month._id;
+        }
+    }
+    for (let obj of user.trackers) {
+        delete obj._id;
+    }
+    for (let obj of user.collections) {
+        delete obj._id;
+    }
+    for (let obj of user.imageBlocks) {
+        delete obj._id;
+    }
+    for (let obj of user.audioBlocks) {
+        delete obj._id;
+    }
+    for (let obj of user.textBlocks) {
+        delete obj._id;
+    }
+    for (let obj of user.events) {
+        delete obj._id;
+    }
+    for (let obj of user.tasks) {
+        delete obj._id;
+    }
+    for (let obj of user.signifiers) {
+        delete obj._id;
+    }
+    return user;
+};
 
 describe("Test /auth route", () => {
 
@@ -32,7 +83,7 @@ describe("Test /auth route", () => {
      * @returns The added user.
      */
     const addUser = async (email, password) => {
-        const key = genKeyFromPass(password);
+        const key = genKeyFromPass(email, password);
         const user = await createUser.createUser(email, password, key);
         return user;
     };
@@ -194,5 +245,124 @@ describe("Test /auth route", () => {
         expect(response.header["set-cookie"][0]).toMatch(/sessionAuth=/);
         expect(response.header["set-cookie"][0]).toMatch(/Path=\//);
         expect(response.body).toEqual({ error: null });
+    });
+});
+
+describe("Test POST /user route", () => {
+
+    /**
+     * Reads a user from the database with data encrypted.
+     *
+     * @param {String} email The email of the user get.
+     * @returns The user if found, null otherwise.
+     */
+    const getEncryptedUser = async (email) => {
+        const user = await schema.User.findOne({ email: email }).exec();
+        return JSON.parse(JSON.stringify(user));
+    };
+
+    /**
+     * Reads a user from the database with data decrypted and password stripped.
+     *
+     * @param {String} email The email of the user to get.
+     * @param {String} password The password of the user to get.
+     * @returns The user if found, null otherwise.
+     */
+    const getDecryptedUser = async (email, password) => {
+        const key = genKeyFromPass(email, password);
+        const user = await readUser.readUser(email, key);
+        return JSON.parse(JSON.stringify(user));
+    };
+
+    /* Connect to the in-memory Mongo server */
+    beforeAll(async () => {
+        mongoose.set("useCreateIndex", true);
+        await mongoose.connect(`${globalThis.__MONGO_URI__}${globalThis.__MONGO_DB_NAME__}`, {
+            useUnifiedTopology: true,
+            useNewUrlParser: true
+        });
+    });
+
+    /* Drop the database */
+    afterEach(async () => {
+        await schema.User.deleteMany({});
+    });
+
+    /* Clean up the connection */
+    afterAll(async () => {
+        await mongoose.connection.close();
+    });
+
+    test("Create valid user", async () => {
+        const user = {
+            email: "user@example.com",
+            pwd: "password"
+        };
+        const response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(200);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        let decryptedUser = await getDecryptedUser(user.email, user.pwd);
+        expect(removeIds(response.body)).toEqual(removeIds(decryptedUser));
+
+        const encryptedUser = await getEncryptedUser(user.email, user.pwd);
+        expect(encryptedUser.pwd).toBe(security.passHash(user.pwd));
+    });
+
+    test("Create existing user", async () => {
+        const user = {
+            email: "user@example.com",
+            pwd: "password"
+        };
+        let response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(200);
+
+        response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(500);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        expect(response.body).toEqual({ error: "This email already has an account!" });
+    });
+
+    test("Create existing with empty email", async () => {
+        const user = {
+            email: "",
+            pwd: "password"
+        };
+        const response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(500);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        expect(response.body).toEqual({ error: "Invalid email!" });
+    });
+
+    test("Create existing with invalid email", async () => {
+        const user = {
+            email: "user@whatever",
+            pwd: "password"
+        };
+        const response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(500);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        expect(response.body).toEqual({ error: "Invalid email!" });
+    });
+
+    test("Create existing with empty password", async () => {
+        const user = {
+            email: "user@example.com",
+            pwd: ""
+        };
+        const response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(500);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        expect(response.body).toEqual({ error: "Password is empty!" });
+    });
+
+    test("Create existing with null email", async () => {
+        const user = {
+            email: null,
+            pwd: "password"
+        };
+        const response = await request(app).post("/user").send(user);
+        expect(response.statusCode).toBe(500);
+        expect(response.headers["content-type"]).toMatch(/json/);
+        expect(response.body).toEqual({ error: "Cannot read properties of null (reading 'match')" });
     });
 });

--- a/src/back-end/test/createUser.test.js
+++ b/src/back-end/test/createUser.test.js
@@ -107,4 +107,12 @@ describe("createUser Tests", () => {
         };
         await expect(invEmPwd).rejects.toThrow();
     });
+
+    test("Password hash is not returned", async () => {
+        const EMAIL = "user@email.com";
+        const PWD = "password";
+        const KEY = "ABC123";
+        const user = await createUser(EMAIL, PWD, KEY);
+        await expect(user.pwd).toBeUndefined();
+    });
 });

--- a/src/back-end/test/deleteUser.test.js
+++ b/src/back-end/test/deleteUser.test.js
@@ -67,4 +67,18 @@ describe("deleteUser Tests", () => {
         };
         await expect(deleteEmpty).rejects.toThrow();
     });
+
+    test("User password is not sent", async () => {
+        let user = {
+            email: "foo@gmail.com",
+            pwd: "123ABC"
+        }
+        const KEY = "ABC123";
+        await createUser(user.email, user.pwd, KEY);
+        let success = await checkUser(user);
+        expect(success).toBe(true);
+
+        user = await deleteUser(user.email);
+        expect(user.pwd).toBeUndefined();
+    });
 });


### PR DESCRIPTION
[back-end/app: fixes critical encryption bug](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/f6b07b0a80b502a5e72733071121b9670b53e45c)

Because the encryption scheme used is non-deterministic, the user's
encryption key will never be the same twice. This is really really bad
because they'll have a new encryption key each time they login. This
fixes this issue by changing the encryption scheme.

---

[back-end/deleteUser: prevents user password hash from being sent back](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/f2a3a456567b4d70eab8b86afe32a76a8a165679)

Also adds a test to make sure the user password isn't sent back with the
data.

---

[back-end/createUser: don't return the user with the password hash](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/8a733861cd110c4388696c648b1d109c6f06a13a)

Prevents the user being returned with the password hash.

---

[back-end/test/app: add tests for post /user route](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/d7277d49a11380cb76ea5fdc5fadf2bccb23d03b)

---

[back-end/test/app: add tests for delete /user route](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/dd501ba404e393c172936d25605e2d98cd0e4d8a)

---

[back-end/test/app: add tests for put /user route](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/99b02add094fc4613f9f80369acc02d05b4f127c)

---

[back-end/test/app: add tests for get /user route](https://github.com/cse-112-sp22-group1/cse112-sp22-group1/commit/d98158212aa762101c0738fdb4508f5044a87b83)